### PR TITLE
Expand FFI between Rust userland and C driver

### DIFF
--- a/kernel/driver.c
+++ b/kernel/driver.c
@@ -2,4 +2,12 @@
 
 void kernel_driver_hello() {
     printf("Kernel driver: Hello from C!\n");
+    fflush(stdout);
 }
+
+int kernel_driver_add(int a, int b) {
+    printf("Kernel driver: adding %d + %d\n", a, b);
+    fflush(stdout);
+    return a + b;
+}
+

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,0 +1,15 @@
+unsafe extern "C" {
+    fn kernel_driver_hello();
+    fn kernel_driver_add(a: i32, b: i32) -> i32;
+}
+
+pub fn hello() {
+    unsafe {
+        kernel_driver_hello();
+    }
+}
+
+pub fn add(a: i32, b: i32) -> i32 {
+    unsafe { kernel_driver_add(a, b) }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,7 @@
-unsafe extern "C" {
-    fn kernel_driver_hello();
-}
+mod driver;
 
 fn main() {
-    unsafe {
-        kernel_driver_hello();
-    }
+    driver::hello();
+    let result = driver::add(2, 3);
+    println!("Result from kernel driver: {}", result);
 }


### PR DESCRIPTION
## Summary
- expose C kernel driver through new Rust `driver` module
- add integer addition routine and newline fix to the C driver
- call new driver API from `main` and print result

## Testing
- `cargo run`


------
https://chatgpt.com/codex/tasks/task_e_68a63b21418c8322af9e77b7f71ba274